### PR TITLE
feat: 0.8.24 android-aarch64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ $ ./scripts/build.sh
 ```
 $ shasum -a 256 ./build/solc/solc
 ```
+
+### Troubleshooting
+
+#### Error running on Android: `CANNOT LINK EXECUTABLE`
+
+Install the `jsoncpp` package:
+
+```console
+pkg install jsoncpp
+```

--- a/android/aarch64/list.json
+++ b/android/aarch64/list.json
@@ -1,0 +1,11 @@
+{
+  "builds": [
+    {
+      "version": "0.8.24",
+      "sha256": "54c813c05e44dcaa692e301f8b0e45abbddd81dd7a8a9a87e9f52b787ef516ce"
+    }
+  ],
+  "releases": {
+    "0.8.24": "solc-v0.8.24"
+  }
+}


### PR DESCRIPTION
Adds `solc` v0.8.24 build for `android-aarch64`. Tested with a `svm-rs` fork in `forge`. Works well on my phone. Can finally use foundry on my phone now :)

The build itself was built from [termux-packages#30e10c093](https://github.com/termux/termux-packages/commit/30e10c093785421167b9556e555690c3d54744c6).